### PR TITLE
Allow support for private ips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.swp
 *.gem
 *.rbc
 .bundle

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Adjust below template as required.  The following configuration is mandatory:
    - shape
    - subnet\_id
 
+Note: The availability domain should be the full AD name including the tenancy specific prefix.  For example: "AaBb:US-ASHBURN-AD-1".  Look in the OCI console to get your tenancy specific string.
+
 These settings are optional:
 
    - oci\_config\_file, by default this is ~/.oci/config
@@ -74,15 +76,22 @@ verifier:
 platforms:
   - name: ubuntu-16.04
     driver:
-      availability_domain: "ad1"
+      # These are mandatory
       compartment_id: "ocid1.compartment.oc1..xxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+      availability_domain: "XyAb:US-ASHBURN-AD-1"
       image_id: "ocid1.image.oc1.phx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
       shape: "VM.Standard1.2"
       subnet_id: "ocid1.subnet.oc1.phx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+      # These are optional
+      use_private_ip: false
+      oci_config_file: "~/.oci/config"
+      oci_profile_name: "DEFAULT"
+      ssh_keypath: "~/.ssh/id_rsa.pub"
       post_create_script: >-
         touch /tmp/example.txt;
     transport:
-      username: "opc"
+      username: "ubuntu"
 
 suites:
   - name: default

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'cane/rake_task'
 require 'tailor/rake_task'

--- a/kitchen-oci.gemspec
+++ b/kitchen-oci.gemspec
@@ -1,4 +1,6 @@
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'kitchen/driver/oci_version'
 

--- a/lib/kitchen/driver/oci_version.rb
+++ b/lib/kitchen/driver/oci_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Author:: Stephen Pearson (<stevieweavie@gmail.com>)
 #
@@ -18,6 +20,6 @@
 module Kitchen
   module Driver
     # Version string for Oracle OCI Kitchen driver
-    OCI_VERSION = '1.0.0'.freeze
+    OCI_VERSION = '1.1.0'
   end
 end


### PR DESCRIPTION
This PR adds an optional boolean to select whether kitchen will connect via the private ip or the public ip.
```
use_private_ip: false
```
Default is false, meaning that the public ip is used.