### PR TITLE
Auto set use_private_ip for private subnets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,15 @@ Note: The availability domain should be the full AD name including the tenancy s
 
 These settings are optional:
 
+   - use\_private\_ip, Whether to connect to the instance using a private IP, default is false (public ip)
    - oci\_config\_file, OCI configuration file, by default this is ~/.oci/config
    - oci\_profile\_name, OCI profile to use, default value is "DEFAULT"
    - ssh\_keypath, SSH public key, default is ~/.ssh/id\_rsa.pub
-   - post\_create\_script, run a script on compute_instance after deployment
+   - post\_create\_script, run a script on compute\_instance after deployment
+
+The use\_private\_ip influences whether the public or private IP will be used by Kitchen to connect to the instance.  If it is set to false (the default) then it will connect to the public IP, otherwise it'll use the private IP.
+
+If the subnet\_id refers to a subnet configured to disallow public IPs on any attached VNICs, then the VNIC will be created without a public IP and the use\_private\_ip flag will assumed to be true irrespective of the config setting.  On subnets that do allow a public IP a public IP will be allocated to the VNIC, but the use\_private\_ip flag can still be used to override whether the private or public IP will be used.
 
 ```
 ---

--- a/kitchen-oci.gemspec
+++ b/kitchen-oci.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'oci', '2.1.0'
+  spec.add_dependency 'oci', '~> 2.1'
   spec.add_dependency 'test-kitchen'
 
   spec.add_development_dependency 'bundler'

--- a/lib/kitchen/driver/oci.rb
+++ b/lib/kitchen/driver/oci.rb
@@ -117,7 +117,11 @@ module Kitchen
 
       def instance_ip(config, instance_id)
         vnic = vnics(config, instance_id).select(&:is_primary).first
-        config[:use_private_ip] ? vnic.private_ip : vnic.public_ip
+        if public_ip_allowed?(config)
+          config[:use_private_ip] ? vnic.private_ip : vnic.public_ip
+        else
+          vnic.private_ip
+        end
       end
 
       def pubkey(config)

--- a/lib/kitchen/driver/oci_version.rb
+++ b/lib/kitchen/driver/oci_version.rb
@@ -20,6 +20,6 @@
 module Kitchen
   module Driver
     # Version string for Oracle OCI Kitchen driver
-    OCI_VERSION = '1.2.0'
+    OCI_VERSION = '1.2.1'
   end
 end


### PR DESCRIPTION
Set use_private_ip automatically for subnets which do not permit public ips.

Update README.