### PR TITLE
Fixes bug in ChefDK

### DIFF
--- a/kitchen-oci.gemspec
+++ b/kitchen-oci.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'oci', '~> 2.5'
+  spec.add_dependency 'oci', '~> 2.5.9'
   spec.add_dependency 'test-kitchen'
 
   spec.add_development_dependency 'bundler'

--- a/lib/kitchen/driver/oci.rb
+++ b/lib/kitchen/driver/oci.rb
@@ -17,6 +17,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This require fixes bug in ChefDK 4.0.60-1 on Linux.
+require 'forwardable'
+
 require 'base64'
 require 'erb'
 require 'kitchen'

--- a/lib/kitchen/driver/oci_version.rb
+++ b/lib/kitchen/driver/oci_version.rb
@@ -20,6 +20,6 @@
 module Kitchen
   module Driver
     # Version string for Oracle OCI Kitchen driver
-    OCI_VERSION = '1.6.0'
+    OCI_VERSION = '1.6.1'
   end
 end


### PR DESCRIPTION
In some ChefDK releases (e.g. 4.0.60-1 on Linux), loading the jwt
library in Ruby triggers an error loading "JWT::JWK::RSA::Forwardable".
The oci library requires this library, so this workaround ensures that
the Forwardable mixin is already loaded.