### PR TITLE
Adding Instance Principal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,14 +130,6 @@ suites:
 
 If you are launching Kitchen from a compute instance running in OCI then you might prefer to use Instance Principals to authenticate to the OCI APIs.  To set this up you can omit the `oci_config_file` and `oci_profile_name` settings and insert `use_instance_principals: true` into your .kitchen.yml instead.
 
-__Important__: If you want to configure a proxy when using Instance Principals, ensure you define the `no_proxy` environment variable so that all link-local access bypasses the proxy.  For example:
-
-```sh
-export no_proxy=169.254.0.0/16
-```
-
-This will allow the OCI lib to retrieve the certificate, key and ca-chain from the metadata service.
-
 ```yml
 platforms:
   - name: ubuntu-18.04
@@ -146,6 +138,14 @@ platforms:
       use_instance_principals: true
       ...
 ```
+
+__Important__: If you want to configure a proxy when using Instance Principals, ensure you define the `no_proxy` environment variable so that all link-local access bypasses the proxy.  For example:
+
+```sh
+export no_proxy=169.254.0.0/16
+```
+
+This will allow the OCI lib to retrieve the certificate, key and ca-chain from the metadata service.
 
 ## Support for user data scripts and cloud-init
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ pull the Chef binaries.
 
 ## Building the gem
 
+This step is only necessary if you wish to make local modifications.  The gem
+has already been published to rubygems.org.
+
 ```bash
 rake build
 ```
@@ -69,6 +72,7 @@ These settings are optional:
    - user\_data, Add user data scripts
    - hostname\_prefix, Prefix for the generated hostnames (note that OCI doesn't like underscores)
    - freeform\_tags, Hash containing tag name(s) and values(s)
+   - use\_instance\_principals, Boolean flag indicated whether Instance Principals should be used as credentials (see below)
 
 Optional settings for WinRM support in Windows:
 
@@ -120,6 +124,19 @@ suites:
       inspec_tests:
         - test/smoke/default
     attributes:
+```
+
+## Instance Principals
+
+If you are launching Kitchen from a compute instance running in OCI then you might prefer to use Instance Principals to authenticate to the OCI APIs.  To set this up you can omit the `oci_config_file` and `oci_profile_name` settings and insert `use_instance_principals: true` into your .kitchen.yml instead.
+
+```yml
+platforms:
+  - name: ubuntu-18.04
+    driver:
+      ...
+      use_instance_principals: true
+      ...
 ```
 
 ## Support for user data scripts and cloud-init

--- a/README.md
+++ b/README.md
@@ -130,6 +130,14 @@ suites:
 
 If you are launching Kitchen from a compute instance running in OCI then you might prefer to use Instance Principals to authenticate to the OCI APIs.  To set this up you can omit the `oci_config_file` and `oci_profile_name` settings and insert `use_instance_principals: true` into your .kitchen.yml instead.
 
+__Important__: If you want to configure a proxy when using Instance Principals, ensure you define the `no_proxy` environment variable so that all link-local access bypasses the proxy.  For example:
+
+```sh
+export no_proxy=169.254.0.0/16
+```
+
+This will allow the OCI lib to retrieve the certificate, key and ca-chain from the metadata service.
+
 ```yml
 platforms:
   - name: ubuntu-18.04
@@ -185,6 +193,8 @@ transport:
   ssh_http_proxy_user: <proxy_user>
   ssh_http_proxy_password: <proxy_password>
 ```
+
+See also the section above on Instance Principals if you plan to use a proxy in conjunction with a proxy.  The proxy needs to be avoided when accessing the metadata address.
 
 ## Windows Support
 

--- a/lib/kitchen/driver/oci.rb
+++ b/lib/kitchen/driver/oci.rb
@@ -54,6 +54,7 @@ module Kitchen
       default_config :setup_winrm, false
       default_config :winrm_user, 'opc'
       default_config :winrm_password, nil
+      default_config :use_instance_principals, false
 
       def process_freeform_tags(freeform_tags)
         prov = instance.provisioner.instance_variable_get(:@config)
@@ -142,11 +143,14 @@ module Kitchen
 
       def generic_api(klass)
         api_prx = api_proxy
-        if api_prx
-          klass.new(config: oci_config, proxy_settings: api_prx)
+        if config[:use_instance_principals]
+          sign = OCI::Auth::Signers::InstancePrincipalsSecurityTokenSigner.new
+          params = { signer: sign }
         else
-          klass.new(config: oci_config)
+          params = { config: oci_config }
         end
+        params[:proxy_settings] = api_prx if api_prx
+        klass.new(**params)
       end
 
       def comp_api

--- a/lib/kitchen/driver/oci_version.rb
+++ b/lib/kitchen/driver/oci_version.rb
@@ -20,6 +20,6 @@
 module Kitchen
   module Driver
     # Version string for Oracle OCI Kitchen driver
-    OCI_VERSION = '1.8.0'
+    OCI_VERSION = '1.9.0'
   end
 end


### PR DESCRIPTION
- Added a new setting to .kitchen.yml called `use_instance_principals`.
Setting this to true will modify the behaviour of the generic_api
method and make it use an
OCI::Auth::Signers::InstancePrincipalsSecurityTokenSigner signer instead
of oci_config.

- Documented instance principals in README.md

- Small modifications to README.md for clarity