### PR TITLE
Removed characters from password string known to break winrm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+
+## 1.12.0
+- Removed characters from password string known to break winrm
+
+## 1.11.0
+- Added support for user_data raw string
+
 ## 1.10.1 Issue 22
 - Added safeguard for cluster_name length restriction in DBaaS.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 
-## 1.12.0
+## 1.11.1
 - Removed characters from password string known to break winrm
 
 ## 1.11.0
@@ -26,3 +26,7 @@
 - Added cloud-init support.
 - Added support for Windows targets.
   - Can inject powershell script to set a random password and enable WinRM
+
+
+steele.justin@gmail.com
+3s!T8mRb6xbz%y

--- a/lib/kitchen/driver/oci.rb
+++ b/lib/kitchen/driver/oci.rb
@@ -237,7 +237,7 @@ module Kitchen
 
       def random_password
         if instance_type == 'compute'
-          special_chars = %w[! " # & ( ) * + , - . /]
+          special_chars = %w[! " & ( ) * + , - . /]
         elsif instance_type == 'dbaas'
           special_chars = %w[# _ -]
         end

--- a/lib/kitchen/driver/oci_version.rb
+++ b/lib/kitchen/driver/oci_version.rb
@@ -20,6 +20,6 @@
 module Kitchen
   module Driver
     # Version string for Oracle OCI Kitchen driver
-    OCI_VERSION = '1.11.0'
+    OCI_VERSION = '1.12.0'
   end
 end

--- a/lib/kitchen/driver/oci_version.rb
+++ b/lib/kitchen/driver/oci_version.rb
@@ -20,6 +20,6 @@
 module Kitchen
   module Driver
     # Version string for Oracle OCI Kitchen driver
-    OCI_VERSION = '1.12.0'
+    OCI_VERSION = '1.11.1'
   end
 end


### PR DESCRIPTION
We have found that the inclusion of # in the randomly generated passwords can cause WinRM authentication to fail.