### PR TITLE
Winrm password complexity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 1.11.2
+- Set oci version dep back to 2.6.0
+
 ## 1.11.1
 - Removed characters from password string known to break winrm
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,3 @@
 - Added cloud-init support.
 - Added support for Windows targets.
   - Can inject powershell script to set a random password and enable WinRM
-
-
-steele.justin@gmail.com
-3s!T8mRb6xbz%y

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+
+## 1.12.0
+- Removed characters from password string known to break winrm
+
+## 1.11.0
+- Added support for user_data raw string
+
 ## 1.10.1 Issue 22
 - Added safeguard for cluster_name length restriction in DBaaS.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,3 @@
 - Added cloud-init support.
 - Added support for Windows targets.
   - Can inject powershell script to set a random password and enable WinRM
-
-
-steele.justin@gmail.com
-3s!T8mRb6xbz%y

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 
-## 1.12.0
+## 1.11.1
 - Removed characters from password string known to break winrm
 
 ## 1.11.0
@@ -26,3 +26,7 @@
 - Added cloud-init support.
 - Added support for Windows targets.
   - Can inject powershell script to set a random password and enable WinRM
+
+
+steele.justin@gmail.com
+3s!T8mRb6xbz%y

--- a/kitchen-oci.gemspec
+++ b/kitchen-oci.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'oci', '~> 2.9.0'
+  spec.add_dependency 'oci', '~> 2.6.0'
   spec.add_dependency 'test-kitchen'
 
   spec.add_development_dependency 'bundler'

--- a/lib/kitchen/driver/oci.rb
+++ b/lib/kitchen/driver/oci.rb
@@ -237,7 +237,7 @@ module Kitchen
 
       def random_password
         if instance_type == 'compute'
-          special_chars = %w[! " # & ( ) * + , - . /]
+          special_chars = %w[! " & ( ) * + , - . /]
         elsif instance_type == 'dbaas'
           special_chars = %w[# _ -]
         end

--- a/lib/kitchen/driver/oci_version.rb
+++ b/lib/kitchen/driver/oci_version.rb
@@ -20,6 +20,6 @@
 module Kitchen
   module Driver
     # Version string for Oracle OCI Kitchen driver
-    OCI_VERSION = '1.11.0'
+    OCI_VERSION = '1.12.0'
   end
 end

--- a/lib/kitchen/driver/oci_version.rb
+++ b/lib/kitchen/driver/oci_version.rb
@@ -20,6 +20,6 @@
 module Kitchen
   module Driver
     # Version string for Oracle OCI Kitchen driver
-    OCI_VERSION = '1.11.1'
+    OCI_VERSION = '1.11.2'
   end
 end

--- a/lib/kitchen/driver/oci_version.rb
+++ b/lib/kitchen/driver/oci_version.rb
@@ -20,6 +20,6 @@
 module Kitchen
   module Driver
     # Version string for Oracle OCI Kitchen driver
-    OCI_VERSION = '1.12.0'
+    OCI_VERSION = '1.11.1'
   end
 end


### PR DESCRIPTION
Fixing things @slippman found in the last commit.

Also changing the oci gem dep back to 2.6.0.  Want to discuss why the change was made to go to 2.9.0.  This lower version appears to still work and avoids warning output filed in https://github.com/oracle/oci-ruby-sdk/issues/45