### PR TITLE
bumping version dep on oci to 2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 1.11.2
+- Set dependency on oci gem to 2.10.0
+
 ## 1.11.1
 - Removed characters from password string known to break winrm
 
@@ -26,7 +29,3 @@
 - Added cloud-init support.
 - Added support for Windows targets.
   - Can inject powershell script to set a random password and enable WinRM
-
-
-steele.justin@gmail.com
-3s!T8mRb6xbz%y

--- a/kitchen-oci.gemspec
+++ b/kitchen-oci.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'oci', '~> 2.9.0'
+  spec.add_dependency 'oci', '~> 2.10.0'
   spec.add_dependency 'test-kitchen'
 
   spec.add_development_dependency 'bundler'

--- a/lib/kitchen/driver/oci_version.rb
+++ b/lib/kitchen/driver/oci_version.rb
@@ -20,6 +20,6 @@
 module Kitchen
   module Driver
     # Version string for Oracle OCI Kitchen driver
-    OCI_VERSION = '1.11.1'
+    OCI_VERSION = '1.11.2'
   end
 end


### PR DESCRIPTION
this bumps the version dependency on the oci gem to 2.10.0.

oci 2.10.0 fixes https://github.com/oracle/oci-ruby-sdk/issues/45, which causes:
```
warning: already initialized constant OCI::Identity::Models::BaseTagDefinitionValidator::VALIDATOR_TYPE_ENUM
warning: previous definition of VALIDATOR_TYPE_ENUM was here
```
