### PR TITLE
refactor: 🚨 oci_config method deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+## 1.12.1
+- Refactor `oci_config` method to account for `warning: Using the last argument as keyword parameters is deprecated` deprecation warning
+- Set dependency on oci gem to 2.15.0
+
 ## 1.12.0
 - Added support for Flex and Preemptible instances
 - Set dependency on oci gem to 2.14.0

--- a/kitchen-oci.gemspec
+++ b/kitchen-oci.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'oci', '~> 2.14.0'
+  spec.add_dependency 'oci', '~> 2.15.0'
   spec.add_dependency 'test-kitchen'
 
   spec.add_development_dependency 'bundler'

--- a/lib/kitchen/driver/oci.rb
+++ b/lib/kitchen/driver/oci.rb
@@ -131,12 +131,10 @@ module Kitchen
       # OCI config setup #
       ####################
       def oci_config
-        params = [:load_config]
         opts = {}
         opts[:config_file_location] = config[:oci_config_file] if config[:oci_config_file]
         opts[:profile_name] = config[:oci_profile_name] if config[:oci_profile_name]
-        params << opts
-        OCI::ConfigFileLoader.send(*params)
+        OCI::ConfigFileLoader.load_config(**opts)
       end
 
       def proxy_config

--- a/lib/kitchen/driver/oci_version.rb
+++ b/lib/kitchen/driver/oci_version.rb
@@ -20,6 +20,6 @@
 module Kitchen
   module Driver
     # Version string for Oracle OCI Kitchen driver
-    OCI_VERSION = '1.12.0'
+    OCI_VERSION = '1.12.1'
   end
 end


### PR DESCRIPTION
This MR addresses the following warnings that show up when using ruby 2.7.0 and higher:
```
kitchen-oci-1.12.0/lib/kitchen/driver/oci.rb:139: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
oci-2.14.0/lib/oci/config_file_loader.rb:34: warning: The called method `load_config' is defined here
```