### PR TITLE
Add Network Security Group Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ These settings are optional:
      - `ocpus`, number of CPUs requested
      - `memory_in_gbs`, the amount of memory requested
      - `baseline_ocpu_utilization`, the minimum CPU utilization, default `BASELINE_1_1`
+   - `nsg_ids`, The option to connect up to 5 Network Security Groups to compute instance.
 
 Optional settings for WinRM support in Windows:
 
@@ -119,6 +120,9 @@ If the `subnet_id` refers to a subnet configured to disallow public IPs on any a
     oci_config_file: "~/.oci/config"
     oci_profile_name: "DEFAULT"
     ssh_keypath: "~/.ssh/id_rsa.pub"
+    nsg_ids:
+      - ocid1.networksecuritygroup.oc1.phx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      - ocid1.networksecuritygroup.oc1.phx.yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
     post_create_script: >-
 ```
 

--- a/lib/kitchen/driver/oci.rb
+++ b/lib/kitchen/driver/oci.rb
@@ -372,10 +372,12 @@ module Kitchen
       end
 
       def create_vnic_details(name)
+        raise 'nsg_ids cannot have more than 5 NSGs.' if config[:nsg_ids].length > 5
         OCI::Core::Models::CreateVnicDetails.new(
           assign_public_ip: public_ip_allowed?,
           display_name: name,
           hostname_label: name,
+          nsg_ids: config[:nsg_ids] || [],
           subnetId: config[:subnet_id]
         )
       end


### PR DESCRIPTION
This PR will resolve issue #40. This feature will allow a user to add an optional nsg_ids argument with an array of up to 5 maximum Network Security Groups. If the user enters more than 5 nsg_ids, kitchen will raise an error. If the user leaves this blank, an empty array will be sent to leave the nsg_ids field blank. 