### PR TITLE
added support for multiple additional volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ These settings are optional:
      - `ocpus`, number of CPUs requested
      - `memory_in_gbs`, the amount of memory requested
      - `baseline_ocpu_utilization`, the minimum CPU utilization, default `BASELINE_1_1`
+  - `volumes`, an array of hashes with configuration options of each volume
+    - `name`, the display name of the volume
+    - `size_in_gbs`, the size in Gbs for the volume. Can't be lower than 50Gbs (Oracle Limit)
+    - `type`, oracle only supports `iscsi` or `paravirtualized` options
 
 Optional settings for WinRM support in Windows:
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ These settings are optional:
     - `name`, the display name of the volume
     - `size_in_gbs`, the size in Gbs for the volume. Can't be lower than 50Gbs (Oracle Limit)
     - `type`, oracle only supports `iscsi` or `paravirtualized` options
+    - `vpus_per_gb`, vpus per gb. Make sure to consult the documentation for your shape to take advantage of UHP as MultiPath is enabled only with certain combinations of memory/cpus.
 
 Optional settings for WinRM support in Windows:
 

--- a/lib/kitchen/driver/oci.rb
+++ b/lib/kitchen/driver/oci.rb
@@ -493,7 +493,8 @@ module Kitchen
           volume = volume_create(
             config[:availability_domain],
             vol_settings[:name],
-            vol_settings[:size_in_gbs]
+            vol_settings[:size_in_gbs],
+            vol_settings[:vpus_per_gb] || 10
           ).to_hash
           # convert to string otherwise it's a ruby datetime object and won't load
           volume[:attachment_type] = vol_settings[:type]
@@ -503,14 +504,15 @@ module Kitchen
         created_vol
       end
 
-      def volume_create(availability_domain, display_name, size_in_gbs)
+      def volume_create(availability_domain, display_name, size_in_gbs, vpus_per_gb)
         info("Creating volume <#{display_name}>...")
         result = blockstorage_api.create_volume(
           OCI::Core::Models::CreateVolumeDetails.new(
             compartment_id: compartment_id,
             availability_domain: availability_domain,
             display_name: display_name,
-            size_in_gbs: size_in_gbs
+            size_in_gbs: size_in_gbs,
+            vpus_per_gb: vpus_per_gb
           )
         )
         get_volume_response = blockstorage_api.get_volume(result.data.id)

--- a/lib/kitchen/driver/oci.rb
+++ b/lib/kitchen/driver/oci.rb
@@ -28,7 +28,6 @@ require 'oci'
 require 'openssl'
 require 'uri'
 require 'zlib'
-require 'json'
 
 module Kitchen
   module Driver

--- a/lib/kitchen/driver/oci.rb
+++ b/lib/kitchen/driver/oci.rb
@@ -28,6 +28,7 @@ require 'oci'
 require 'openssl'
 require 'uri'
 require 'zlib'
+require 'json'
 
 module Kitchen
   module Driver
@@ -70,6 +71,9 @@ module Kitchen
       # dbaas config items
       default_config :dbaas, {}
 
+      # blockstorage config items
+      default_config :volumes, {}
+
       def create(state)
         return if state[:server_id]
 
@@ -82,6 +86,9 @@ module Kitchen
 
         instance.transport.connection(state).wait_until_ready
 
+        state[:volumes] = process_volumes_list(state)
+        state[:volume_attachments] = process_volume_attachments(state)
+
         return unless config[:post_create_script]
 
         info('Running post create script')
@@ -93,6 +100,18 @@ module Kitchen
         return unless state[:server_id]
 
         instance.transport.connection(state).close
+
+        if state[:volume_attachments]
+          state[:volume_attachments].each do |attachment|
+            volume_detach(attachment)
+          end
+        end
+
+        if state[:volumes]
+          state[:volumes].each do |vol|
+            volume_delete(vol[:id])
+          end
+        end
 
         if instance_type == 'compute'
           comp_api.terminate_instance(state[:server_id])
@@ -229,6 +248,10 @@ module Kitchen
 
       def ident_api
         generic_api(OCI::Identity::IdentityClient)
+      end
+
+      def blockstorage_api
+        generic_api(OCI::Core::BlockstorageClient)
       end
 
       ##################
@@ -459,6 +482,95 @@ module Kitchen
         elsif config[:user_data].is_a? String
           Base64.encode64(config[:user_data]).delete("\n")
         end
+      end
+
+      ########################
+      # BlockStorage methods #
+      ########################
+      def process_volumes_list(state)
+        created_vol = []
+        config[:volumes].each do |vol_settings|
+          # convert to hash because otherwise it's an an OCI API Object and won't load
+          volume = volume_create(
+            config[:availability_domain],
+            vol_settings[:name],
+            vol_settings[:size_in_gbs]
+          ).to_hash
+          # convert to string otherwise it's a ruby datetime object and won't load
+          volume[:attachment_type] = vol_settings[:type]
+          volume[:timeCreated] = volume[:timeCreated].to_s
+          created_vol << volume
+        end
+        created_vol
+      end
+
+      def volume_create(availability_domain, display_name, size_in_gbs)
+        info("Creating volume <#{display_name}>...")
+        result = blockstorage_api.create_volume(
+          OCI::Core::Models::CreateVolumeDetails.new(
+            compartment_id: compartment_id,
+            availability_domain: availability_domain,
+            display_name: display_name,
+            size_in_gbs: size_in_gbs
+          )
+        )
+        get_volume_response = blockstorage_api.get_volume(result.data.id)
+                                              .wait_until(:lifecycle_state, OCI::Core::Models::Volume::LIFECYCLE_STATE_AVAILABLE)
+        info("Finished creating volume <#{display_name}>.")
+        get_volume_response.data
+      end
+
+      def volume_delete(volume_id)
+        info("Deleting volume: <#{volume_id}>...")
+        blockstorage_api.delete_volume(volume_id)
+        blockstorage_api.get_volume(volume_id)
+                        .wait_until(:lifecycle_state, OCI::Core::Models::Volume::LIFECYCLE_STATE_TERMINATED)
+        info("Deleted volume: <#{volume_id}>")
+      end
+
+      def process_volume_attachments(state)
+        attachments = []
+        state[:volumes].each do |volume|
+          info("Attaching Volume: #{volume[:displayName]} - #{volume[:attachment_type]}")
+          details = volume_create_attachment_details(volume, state[:server_id])
+          attachment = volume_attach(details).to_hash
+          attachment[:timeCreated] = attachment[:timeCreated].to_s
+          attachments << attachment
+          info("Attached Volume #{volume[:displayName]} - #{volume[:attachment_type]}")
+        end
+        attachments
+      end
+
+      def volume_create_attachment_details(volume, instance_id)
+        if volume[:attachment_type].eql?('iscsi')
+          OCI::Core::Models::AttachIScsiVolumeDetails.new(
+            display_name: 'iSCSIAttachment',
+            volume_id: volume[:id],
+            instance_id: instance_id
+          )
+        else
+          OCI::Core::Models::AttachParavirtualizedVolumeDetails.new(
+            display_name: 'paravirtAttachment',
+            volume_id: volume[:id],
+            instance_id: instance_id
+          )
+        end
+      end
+
+      def volume_attach(volume_attachment_details)
+        result = comp_api.attach_volume(volume_attachment_details)
+        get_volume_attachment_response =
+          comp_api.get_volume_attachment(result.data.id)
+                  .wait_until(:lifecycle_state, OCI::Core::Models::VolumeAttachment::LIFECYCLE_STATE_ATTACHED)
+        get_volume_attachment_response.data
+      end
+
+      def volume_detach(volume_attachment)
+        info("Detaching volume: #{volume_attachment[:id]}")
+        comp_api.detach_volume(volume_attachment[:id])
+        comp_api.get_volume_attachment(volume_attachment[:id])
+                .wait_until(:lifecycle_state, OCI::Core::Models::VolumeAttachment::LIFECYCLE_STATE_DETACHED)
+        info("Detached volume: #{volume_attachment[:id]}")
       end
 
       #################

--- a/lib/kitchen/driver/oci_version.rb
+++ b/lib/kitchen/driver/oci_version.rb
@@ -20,6 +20,6 @@
 module Kitchen
   module Driver
     # Version string for Oracle OCI Kitchen driver
-    OCI_VERSION = '1.12.3'
+    OCI_VERSION = '1.12.4'
   end
 end

--- a/lib/kitchen/driver/oci_version.rb
+++ b/lib/kitchen/driver/oci_version.rb
@@ -20,6 +20,6 @@
 module Kitchen
   module Driver
     # Version string for Oracle OCI Kitchen driver
-    OCI_VERSION = '2.0.0'
+    OCI_VERSION = '1.12.4'
   end
 end

--- a/lib/kitchen/driver/oci_version.rb
+++ b/lib/kitchen/driver/oci_version.rb
@@ -20,6 +20,6 @@
 module Kitchen
   module Driver
     # Version string for Oracle OCI Kitchen driver
-    OCI_VERSION = '1.12.4'
+    OCI_VERSION = '2.0.0'
   end
 end


### PR DESCRIPTION
## Purpose:

This change allows you to add any number of volumes to your test-kitchen instances. 

### Example usage:

```yaml
---
driver:
  name: oci
  compartment_id: ENV['COMPARTMENT_ID']
  availability_domain: ENV['AVAILABILITY_DOMAIN']
  image_id: ENV['IMAGE_ID']
  region: ENV['REGION']
  shape: ENV['SHAPE']
  shape_config:
    ocpus: 16
    memory_in_gbs: 32
  subnet_id: ENV['SUBNET]
  volumes:
    - name: volume-1
      size_in_gbs: 70
      type: iscsi
    - name: volume-2
      size_in_gbs: 60
      vpus_per_gb: 30
  ```
  
  Using `iscsi` still requires you to connect to the iscsiadm using the following commands:
  
  ```shell
iscsiadm -m node -o new -T $IQN -p $IQN_IPv4:$IQN_PORT
iscsiadm -m node -o update -T $IQN -n node.startup -v automatic
iscsiadm -m node -T $IQN -p $IQN_IPv4:$IQN_PORT -l
  ```
  
  The values for the above can be found inside of the state or inside.
  
 ### Example Output:
  
```
-----> Starting Test Kitchen (v3.6.0)
-----> Destroying <default-ubuntu-2204>...
       Finished destroying <default-ubuntu-2204> (0m0.00s).
-----> Test Kitchen is finished. (0m10.10s)
-----> Starting Test Kitchen (v3.6.0)
-----> Creating <default-ubuntu-2204>...
       [SSH] Established
       Creating volume <volume-1>...with 10
       Finished creating volume <volume-1>.
       Creating volume <volume-2>...with 30
       Finished creating volume <volume-2>.
       Attaching Volume: volume-1 - iscsi
       Attached Volume volume-1 - iscsi
       Attaching Volume: volume-2 - paravirtual
       Attached Volume volume-2 - paravirtual
       Finished creating <default-ubuntu-2204> (3m1.34s).
-----> Test Kitchen is finished. (3m10.75s)
```