### PR TITLE
Creating custom metadata for compute requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # kitchen-oci CHANGELOG
+# 1.15.0
+- feat: add optional parameter `custom_metadata`
 
 # 1.14.0
 - feat: add optional parameter `defined_tags`
-- 
 
 # 1.13.0
 - feat: add Network Security Group support

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ These settings are optional:
      - `type`, oracle only supports `iscsi` or `paravirtual` options (default: `paravirtual`)
      - `vpus_per_gb`, vpus per gb. Make sure to consult the documentation for your shape to take advantage of UHP as MultiPath is enabled only with certain combinations of memory/cpus.
    - `nsg_ids`, The option to connect up to 5 Network Security Groups to compute instance.
+   - `custom_metadata`, Add metadata to the compute instance request
 
 Optional settings for WinRM support in Windows:
 
@@ -149,6 +150,9 @@ If the `subnet_id` refers to a subnet configured to disallow public IPs on any a
     nsg_ids:
       - ocid1.networksecuritygroup.oc1.phx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       - ocid1.networksecuritygroup.oc1.phx.yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+    custom_metadata:
+      key1: value1
+      key2: value2
     post_create_script: >-
 ```
 

--- a/lib/kitchen/driver/oci.rb
+++ b/lib/kitchen/driver/oci.rb
@@ -67,6 +67,7 @@ module Kitchen
       default_config :use_token_auth, false
       default_config :preemptible_instance, false
       default_config :shape_config, {}
+      default_config :custom_metadata, {}
 
       # dbaas config items
       default_config :dbaas, {}
@@ -347,6 +348,10 @@ module Kitchen
         inject_powershell(state) if config[:setup_winrm] == true
 
         metadata = {}
+        md = config[:custom_metadata]
+        md.each do |key, value|
+          metadata.store(key, value)
+        end
         metadata.store('ssh_authorized_keys', pubkey)
         data = user_data
         metadata.store('user_data', data) if config[:user_data] && !config[:user_data].empty?

--- a/lib/kitchen/driver/oci_version.rb
+++ b/lib/kitchen/driver/oci_version.rb
@@ -20,6 +20,6 @@
 module Kitchen
   module Driver
     # Version string for Oracle OCI Kitchen driver
-    OCI_VERSION = '1.14.1'
+    OCI_VERSION = '1.15.0'
   end
 end

--- a/lib/kitchen/driver/oci_version.rb
+++ b/lib/kitchen/driver/oci_version.rb
@@ -20,6 +20,6 @@
 module Kitchen
   module Driver
     # Version string for Oracle OCI Kitchen driver
-    OCI_VERSION = '1.14.0'
+    OCI_VERSION = '1.14.1'
   end
 end


### PR DESCRIPTION
custom metadata strings can be passed to compute requests, sometimes useful for systems that need custom metadata added to them in addition to things like ssh keys.