### PR TITLE
added source details to volumes (enables volume cloning)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ These settings are optional:
      - `size_in_gbs`, the size in Gbs for the volume. (minimum value: 50GB)
      - `type`, oracle only supports `iscsi` or `paravirtual` options (default: `paravirtual`)
      - `vpus_per_gb`, vpus per gb. Make sure to consult the documentation for your shape to take advantage of UHP as MultiPath is enabled only with certain combinations of memory/cpus.
+     - `volume_id`, If you wish to clone your volume from an existing volume set this to the source volume's ID. They must be in the same Availability Domain.
    - `nsg_ids`, The option to connect up to 5 Network Security Groups to compute instance.
    - `custom_metadata`, Add metadata to the compute instance request
    - `all_plugins_disabled`, Whether Oracle Cloud Agent can run all the available plugins (default: `false`)

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ These settings are optional:
      - `baseline_ocpu_utilization`, the minimum CPU utilization (default: `BASELINE_1_1`)
    - `volumes`, an array of hashes with configuration options of each volume [[more](#block-volume-attachments)]
      - `name`, the display name of the volume
-     - `size_in_gbs`, the size in Gbs for the volume. (minimum value: 50GB)
+     - `size_in_gbs`, the size in Gbs for the volume. (minimum value: 50GB). When used in conjunction with `volume_id`, the size must be equal to or greater than the source volume's size if unset, it will default to the size of the source volume. 
      - `type`, oracle only supports `iscsi` or `paravirtual` options (default: `paravirtual`)
      - `vpus_per_gb`, vpus per gb. Make sure to consult the documentation for your shape to take advantage of UHP as MultiPath is enabled only with certain combinations of memory/cpus.
      - `volume_id`, If you wish to clone your volume from an existing volume set this to the source volume's ID. They must be in the same Availability Domain.

--- a/lib/kitchen/driver/oci.rb
+++ b/lib/kitchen/driver/oci.rb
@@ -156,7 +156,11 @@ module Kitchen
         volume_state = { volumes: [], volume_attachments: [] }
         config[:volumes].each do |volume|
           vol = volume_class(volume[:type], config, state, oci, api)
-          volume_details, vol_state = vol.create_volume(volume)
+          unless volume.has_key?(:volume_id)
+            volume_details, vol_state = vol.create_volume(volume)
+          else
+            volume_details, vol_state = vol.create_clone_volume(volume)
+          end
           attach_state = vol.attach_volume(volume_details, state[:server_id])
           volume_state[:volumes] << vol_state
           volume_state[:volume_attachments] << attach_state

--- a/lib/kitchen/driver/oci.rb
+++ b/lib/kitchen/driver/oci.rb
@@ -156,7 +156,7 @@ module Kitchen
         volume_state = { volumes: [], volume_attachments: [] }
         config[:volumes].each do |volume|
           vol = volume_class(volume[:type], config, state, oci, api)
-          unless volume.has_key?(:volume_id)
+          unless volume.key?(:volume_id)
             volume_details, vol_state = vol.create_volume(volume)
           else
             volume_details, vol_state = vol.create_clone_volume(volume)

--- a/lib/kitchen/driver/oci/blockstorage.rb
+++ b/lib/kitchen/driver/oci/blockstorage.rb
@@ -175,7 +175,6 @@ module Kitchen
         end
 
         def clone_volume_display_name(volume_id)
-          info("#{api.blockstorage.get_volume(volume_id).data.to_hash[:displayName]} (Clone)")
           "#{api.blockstorage.get_volume(volume_id).data.to_hash[:displayName]} (Clone)"
         end
       end

--- a/lib/kitchen/driver/oci/blockstorage.rb
+++ b/lib/kitchen/driver/oci/blockstorage.rb
@@ -86,7 +86,6 @@ module Kitchen
         end
 
         def create_clone_volume(volume)
-          info("This is volume id: #{volume[:volume_id]}")
           clone_volume_name = clone_volume_display_name(volume[:volume_id])
           info("Creating <#{clone_volume_name}>...")
           result = api.blockstorage.create_volume(volume_clone_details(volume, clone_volume_name))
@@ -155,7 +154,7 @@ module Kitchen
           OCI::Core::Models::CreateVolumeDetails.new(
             compartment_id: oci.compartment,
             availability_domain: config[:availability_domain],
-            display_name: volume[:name] || clone_volume_name,
+            display_name: clone_volume_name,
             defined_tags: config[:defined_tags],
             size_in_gbs: volume[:size_in_gbs] || nil,
             vpus_per_gb: volume[:vpus_per_gb] || nil,

--- a/lib/kitchen/driver/oci/blockstorage.rb
+++ b/lib/kitchen/driver/oci/blockstorage.rb
@@ -20,7 +20,7 @@ module Kitchen
   module Driver
     class Oci
       # generic class for blockstorage
-      class Blockstorage < Oci
+      class Blockstorage < Oci # rubocop:disable Metrics/ClassLength
         require_relative "api"
         require_relative "config"
         require_relative "models/iscsi"

--- a/lib/kitchen/driver/oci/blockstorage.rb
+++ b/lib/kitchen/driver/oci/blockstorage.rb
@@ -158,9 +158,7 @@ module Kitchen
             defined_tags: config[:defined_tags],
             size_in_gbs: volume[:size_in_gbs],
             vpus_per_gb: volume[:vpus_per_gb],
-            source_details: OCI::Core::Models::VolumeSourceFromVolumeDetails.new(
-              id: volume[:volume_id]
-            )
+            source_details: OCI::Core::Models::VolumeSourceFromVolumeDetails.new(id: volume[:volume_id])
           )
         end
 

--- a/lib/kitchen/driver/oci/blockstorage.rb
+++ b/lib/kitchen/driver/oci/blockstorage.rb
@@ -156,8 +156,8 @@ module Kitchen
             availability_domain: config[:availability_domain],
             display_name: clone_volume_name,
             defined_tags: config[:defined_tags],
-            size_in_gbs: volume[:size_in_gbs] || nil,
-            vpus_per_gb: volume[:vpus_per_gb] || nil,
+            size_in_gbs: volume[:size_in_gbs],
+            vpus_per_gb: volume[:vpus_per_gb],
             source_details: OCI::Core::Models::VolumeSourceFromVolumeDetails.new(
               id: volume[:volume_id]
             )

--- a/lib/kitchen/driver/oci/blockstorage.rb
+++ b/lib/kitchen/driver/oci/blockstorage.rb
@@ -131,7 +131,7 @@ module Kitchen
         end
 
         def volume_details(volume)
-          OCI::Core::Models::CreateVolumeDetails.new(
+          details = OCI::Core::Models::CreateVolumeDetails.new(
             compartment_id: oci.compartment,
             availability_domain: config[:availability_domain],
             display_name: volume[:name],
@@ -139,6 +139,14 @@ module Kitchen
             vpus_per_gb: volume[:vpus_per_gb] || 10,
             defined_tags: config[:defined_tags]
           )
+
+          if volume.key?(:source_details)
+            details.source_details = OCI::Core::Models::VolumeSourceFromVolumeDetails.new(
+              type: volume[:source_details][:type],
+              id: volume[:source_details][:id]
+            )
+          end
+          details
         end
 
         def attachment_name(attachment)

--- a/lib/kitchen/driver/oci/blockstorage.rb
+++ b/lib/kitchen/driver/oci/blockstorage.rb
@@ -139,7 +139,10 @@ module Kitchen
             vpus_per_gb: volume[:vpus_per_gb] || 10,
             defined_tags: config[:defined_tags]
           )
+          add_volume_source_details(details, volume)
+        end
 
+        def add_volume_source_details(details, volume)
           if volume.key?(:source_details)
             details.source_details = OCI::Core::Models::VolumeSourceFromVolumeDetails.new(
               type: volume[:source_details][:type],

--- a/spec/kitchen/driver/compute_spec.rb
+++ b/spec/kitchen/driver/compute_spec.rb
@@ -232,8 +232,8 @@ describe Kitchen::Driver::Oci::Models::Compute do
                 name: source_volume_name,
                 size_in_gbs: 10,
                 volume_id: source_volume_id,
-              }
-            ]
+              },
+            ],
           })
         end
 
@@ -260,7 +260,7 @@ describe Kitchen::Driver::Oci::Models::Compute do
           OCI::Core::Models::AttachParavirtualizedVolumeDetails.new(
             display_name: clone_attachment_display_name,
             volume_id: clone_volume_ocid,
-            instance_id: instance_ocid,
+            instance_id: instance_ocid
           )
         end
 
@@ -268,7 +268,7 @@ describe Kitchen::Driver::Oci::Models::Compute do
           OCI::Response.new(200, nil, OCI::Core::Models::Volume.new(
             id: clone_volume_ocid,
             display_name: clone_volume_name,
-            lifecycle_state: Lifecycle.volume("available"),
+            lifecycle_state: Lifecycle.volume("available")
           ))
         end
 
@@ -278,7 +278,7 @@ describe Kitchen::Driver::Oci::Models::Compute do
             instance_id: instance_ocid,
             volume_id: clone_volume_ocid,
             display_name: clone_attachment_display_name,
-            lifecycle_state: Lifecycle.volume_attachment("attached"),
+            lifecycle_state: Lifecycle.volume_attachment("attached")
           ))
         end
 
@@ -303,13 +303,13 @@ describe Kitchen::Driver::Oci::Models::Compute do
                 {
                   id: clone_attachment_ocid,
                   display_name: clone_attachment_display_name,
-                }
+                },
               ],
               volumes: [
                 {
                   display_name: clone_volume_name,
                   id: clone_volume_ocid,
-                }
+                },
               ]
             }
           )

--- a/spec/kitchen/driver/compute_spec.rb
+++ b/spec/kitchen/driver/compute_spec.rb
@@ -310,7 +310,7 @@ describe Kitchen::Driver::Oci::Models::Compute do
                   display_name: clone_volume_name,
                   id: clone_volume_ocid,
                 },
-              ]
+              ],
             }
           )
         end

--- a/spec/kitchen/driver/compute_spec.rb
+++ b/spec/kitchen/driver/compute_spec.rb
@@ -231,7 +231,7 @@ describe Kitchen::Driver::Oci::Models::Compute do
               {
                 name: source_volume_name,
                 size_in_gbs: 10,
-                volume_id: source_volume_id
+                volume_id: source_volume_id,
               }
             ]
           })
@@ -260,7 +260,7 @@ describe Kitchen::Driver::Oci::Models::Compute do
           OCI::Core::Models::AttachParavirtualizedVolumeDetails.new(
             display_name: clone_attachment_display_name,
             volume_id: clone_volume_ocid,
-            instance_id: instance_ocid
+            instance_id: instance_ocid,
           )
         end
 
@@ -268,7 +268,7 @@ describe Kitchen::Driver::Oci::Models::Compute do
           OCI::Response.new(200, nil, OCI::Core::Models::Volume.new(
             id: clone_volume_ocid,
             display_name: clone_volume_name,
-            lifecycle_state: Lifecycle.volume("available")
+            lifecycle_state: Lifecycle.volume("available"),
           ))
         end
 
@@ -278,7 +278,7 @@ describe Kitchen::Driver::Oci::Models::Compute do
             instance_id: instance_ocid,
             volume_id: clone_volume_ocid,
             display_name: clone_attachment_display_name,
-            lifecycle_state: Lifecycle.volume_attachment("attached")
+            lifecycle_state: Lifecycle.volume_attachment("attached"),
           ))
         end
 
@@ -302,13 +302,13 @@ describe Kitchen::Driver::Oci::Models::Compute do
               volume_attachments: [
                 {
                   id: clone_attachment_ocid,
-                  display_name: clone_attachment_display_name
+                  display_name: clone_attachment_display_name,
                 }
               ],
               volumes: [
                 {
                   display_name: clone_volume_name,
-                  id: clone_volume_ocid
+                  id: clone_volume_ocid,
                 }
               ]
             }


### PR DESCRIPTION
## What is this?

We need to be able to create volumes with massive amounts of data. It is faster to clone the volume than to copy it over via other methods. 

We just need to add support for `source_details` field inside of the volume creation code. 
More information can be found:

* https://github.com/oracle/oci-ruby-sdk/blob/master/lib/oci/core/models/volume_source_details.rb
* https://docs.oracle.com/en-us/iaas/tools/ruby-sdk-examples/2.21.0/core/create_volume.rb.html

## How to try it out?

1. ) First create, a regular VM and with a volume such as this:

```yaml
---
driver:
  name: oci
  compartment_id: ENV['COMPARTMENT_ID']
  availability_domain: "xJwU:US-ASHBURN-AD-1"
  image_id: ENV['IMAGE_ID']
  region: "us-ashburn-1"
  shape: "VM.Standard.E4.Flex"
  shape_config:
    ocpus: 4
    memory_in_gbs: 16
  subnet_id: ENV['SUBNET_ID']
  ssh_keypath: "<%= ENV['HOME'] %>/.ssh/key.pub"
  oci_profile_name: "us-ashburn-1"
  use_token_auth: true
  defined_tags:
    Node_Info:
      machine: "tk"
  volumes:
    - name: data
      size_in_gbs: 100
      type: paravirtual
```

2.) Create a file inside said VM.

```
ubuntu@role-test-1-tk:/data$ sudo touch jose.was.here.txt && ls -ah
.  ..  jose.was.here.txt  lost+found
```

3.) Create another machine using the above's attached volume in the source details, here's an example:

```yaml
---
driver:
  name: oci
  compartment_id: ENV['COMPARTMENT_ID']
  availability_domain: "xJwU:US-ASHBURN-AD-1"
  image_id: ENV['IMAGE_ID']
  region: "us-ashburn-1"
  shape: "VM.Standard.E4.Flex"
  shape_config:
    ocpus: 4
    memory_in_gbs: 16
  subnet_id: ENV['SUBNET_ID']
  ssh_keypath: "<%= ENV['HOME'] %>/.ssh/key.pub"
  oci_profile_name: "us-ashburn-1"
  use_token_auth: true
  defined_tags:
    Node_Info:
      machine: "tk"
  volumes:
    - volume_id: 'ocid1.volume.oc1.iad.<ID>'
   ```

Create the machine, you should see similar output:

```
-----> Creating <default-ubuntu-2204>...
       [SSH] Established
       Creating <data (Clone)>...
       Finished creating <data (Clone)>.
       Attaching <data (Clone)>...
       Finished attaching <data (Clone)>.
       Finished creating <default-ubuntu-2204> (1m16.09s).
-----> Test Kitchen is finished. (1m17.19s)
```

Once your volume is mounted you should now see the same files.

```
ubuntu@role-test-2-tk:/data$ ls -alh
total 28K
drwxr-xr-x  3 root root 4.0K Aug 24 07:19 .
drwxr-xr-x 20 root root 4.0K Aug 24 07:53 ..
-rw-r--r--  1 root root   13 Aug 24 07:19 jose.was.here.txt
drwx------  2 root root  16K Aug 24 07:17 lost+found
```