### PR TITLE
Update the oci gem lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # kitchen-oci CHANGELOG
 
 # 1.24.0
-  -feat: Set dependency on oci gem to `~> 2.21` 
+- feat: Set dependency on oci gem to `~> 2.21` 
 
 # 1.23.0
 - feat: add `capacity_reservation_id` for compute shapes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # kitchen-oci CHANGELOG
 
+# 1.24.0
+  -feat: Set dependency on oci gem to `~> 2.21` 
+
 # 1.23.0
 - feat: add `capacity_reservation_id` for compute shapes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # kitchen-oci CHANGELOG
 
 # 1.24.0
-- feat: Set dependency on oci gem to `~> 2.21` 
+- feat: change pessimistic lock on oci gem to just `~> 2.18` 
 
 # 1.23.0
 - feat: add `capacity_reservation_id` for compute shapes

--- a/kitchen-oci.gemspec
+++ b/kitchen-oci.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.executables   = []
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "oci", "~> 2.18.0"
+  spec.add_dependency "oci", "~> 2.21"
   spec.add_dependency "test-kitchen"
 
   spec.add_development_dependency "bundler"

--- a/kitchen-oci.gemspec
+++ b/kitchen-oci.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.executables   = []
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "oci", "~> 2.21"
+  spec.add_dependency "oci", "~> 2.18"
   spec.add_dependency "test-kitchen"
 
   spec.add_development_dependency "bundler"

--- a/lib/kitchen/driver/oci_version.rb
+++ b/lib/kitchen/driver/oci_version.rb
@@ -20,6 +20,6 @@
 module Kitchen
   module Driver
     # Version string for Oracle OCI Kitchen driver
-    OCI_VERSION = "1.23.0"
+    OCI_VERSION = "1.24.0"
   end
 end


### PR DESCRIPTION
# 1.24.0
- feat: change pessimistic lock on oci gem to just `~> 2.18` 