### PR TITLE
Arm tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # kitchen-oci CHANGELOG
 
+# 1.24.1
+- fix: allow `image_name` to function the same for ARM as it does for Linux
+
 # 1.24.0
 - feat: change pessimistic lock on oci gem to just `~> 2.18` 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # kitchen-oci CHANGELOG
 
-# 1.24.1
-- fix: allow `image_name` to function the same for ARM as it does for Linux
+# 1.25.0
+- feat: allow `image_name` to function the same for ARM as it does for Linux
 
 # 1.24.0
 - feat: change pessimistic lock on oci gem to just `~> 2.18` 

--- a/README.md
+++ b/README.md
@@ -75,11 +75,16 @@ OR
 Image ocids and display names can be found on the public [OCI Documentation / Images](https://docs.oracle.com/en-us/iaas/images/) page. The `image_name` property allows you to specify the display
 name of the image rather than the ocid.  There are two ways to do this:
 
-- specify the entire image name.  For example, `Oracle-Linux-8.9-2024.02.26-0`
-- specify the un-dated, un-versioned portion of the display name. For example, `Oracle-Linux-8.9`\
+- Specify the entire image name.  For example, `Oracle-Linux-8.9-2024.02.26-0`
+- Specify the un-dated, un-versioned portion of the display name. For example, `Oracle-Linux-8.9`\
      Note: for aesthetics, the dashes can be replaced with spaces `Oracle Linux 8.9`. Both ways work, one way is prettier.
 - Regular Expressions are also supported.  For example, `Oracle Linux 8.\d+` will give the latest `Oracle Linux 8.x`\
      Note: be careful here.  If the regular expression is too broad, the newest image id of the matching set will be returned and might not be of the desired operating system.
+- For an ARM specific `shape` you can add in `-aarch64` to the `image_name`.  For example, `Oracle-Linux-8.9-aarch64-2024.02.26-0` or `Oracle Linux 8.\d+-aarch64`\
+     But you don't have to as if a `shape` matches `VM.Standard.A<##>.Flex` then `-aarch64` gets added automatically and `Oracle Linux 8.\d+` will work the same.\
+     [ARM Documentation Here](https://docs.oracle.com/en-us/iaas/Content/Compute/References/arm.htm)
+- **Caution:** Platform images are refreshed regularly. When new images are released, older versions are replaced. The image OCIDs remain available, but when the platform image is replaced, the image OCIDs are no longer returned as part of the platform image list.\
+     [OCI Documentation Here](https://docs.oracle.com/en-us/iaas/tools/ruby/2.21.0/OCI/Core/ComputeClient.html#list_images-instance_method)
 
 If the second option is chosen (providing a portion of the display name), the behavior is to search all display names that match the string provided plus anything that looks like
 a date, then sort by time created and return the ocid for the newest one. This allows you to always get the latest version of a given image without having to continually update your kitchen.yml files.

--- a/lib/kitchen/driver/oci/models/compute.rb
+++ b/lib/kitchen/driver/oci/models/compute.rb
@@ -67,7 +67,7 @@ module Kitchen
           end
 
           def image_id_by_name
-            image_name = config[:image_name].gsub(" ", "-")
+            image_name = image_name_convertion
             image_list = images.select { |i| i.display_name.match(/#{image_name}/) }
             raise "unable to find image_id" if image_list.empty?
 
@@ -75,6 +75,14 @@ module Kitchen
             raise "unable to find image_id" if image_list.empty?
 
             latest_image_id(image_list)
+          end
+
+          def image_name_convertion
+            image_name = config[:image_name].gsub(" ", "-")
+            if config[:shape] =~ /^VM\.Standard\.A\d+\.Flex$/ && !config[:image_name].include?("aarch64")
+              image_name = "#{image_name}-aarch64"
+            end
+            image_name
           end
 
           def filter_image_list(image_list, image_name)

--- a/lib/kitchen/driver/oci/models/compute.rb
+++ b/lib/kitchen/driver/oci/models/compute.rb
@@ -67,7 +67,7 @@ module Kitchen
           end
 
           def image_id_by_name
-            image_name = image_name_convertion
+            image_name = image_name_conversion
             image_list = images.select { |i| i.display_name.match(/#{image_name}/) }
             raise "unable to find image_id" if image_list.empty?
 
@@ -77,7 +77,7 @@ module Kitchen
             latest_image_id(image_list)
           end
 
-          def image_name_convertion
+          def image_name_conversion
             image_name = config[:image_name].gsub(" ", "-")
             if config[:shape] =~ /^VM\.Standard\.A\d+\.Flex$/ && !config[:image_name].include?("aarch64")
               image_name = "#{image_name}-aarch64"

--- a/lib/kitchen/driver/oci_version.rb
+++ b/lib/kitchen/driver/oci_version.rb
@@ -20,6 +20,6 @@
 module Kitchen
   module Driver
     # Version string for Oracle OCI Kitchen driver
-    OCI_VERSION = "1.24.0"
+    OCI_VERSION = "1.24.1"
   end
 end

--- a/lib/kitchen/driver/oci_version.rb
+++ b/lib/kitchen/driver/oci_version.rb
@@ -20,6 +20,6 @@
 module Kitchen
   module Driver
     # Version string for Oracle OCI Kitchen driver
-    OCI_VERSION = "1.24.1"
+    OCI_VERSION = "1.25.0"
   end
 end

--- a/spec/kitchen/driver/image_id_spec.rb
+++ b/spec/kitchen/driver/image_id_spec.rb
@@ -19,7 +19,6 @@
 
 require "spec_helper"
 
-# First test block: Basic image name selection (without considering the shape)
 describe Kitchen::Driver::Oci::Models::Compute do
   include_context "compute"
   include_context "create"
@@ -62,7 +61,6 @@ describe Kitchen::Driver::Oci::Models::Compute do
   end
 end
 
-# Image name selection with ARM shape set
 describe Kitchen::Driver::Oci::Models::Compute do
   include_context "compute"
   include_context "create"
@@ -75,8 +73,8 @@ describe Kitchen::Driver::Oci::Models::Compute do
       base_driver_config.merge!(
         {
           image_id: nil,
-          image_name: "Oracle-Linux-9.3", # Test with an image name that does not include aarch64
-          shape: "VM.Standard.A1.Flex", # ARM shape
+          image_name: "Oracle-Linux-9.3", # test with an image name that does not include aarch64
+          shape: "VM.Standard.A1.Flex", # Arm shape
         }
       )
     end

--- a/spec/kitchen/driver/image_id_spec.rb
+++ b/spec/kitchen/driver/image_id_spec.rb
@@ -88,7 +88,7 @@ describe Kitchen::Driver::Oci::Models::Compute do
 
     it "adjusts the image name to include -aarch64" do
       expected_image_name = "Oracle-Linux-9.3-aarch64"
-      expect(subject.send(:image_name_convertion)).to eq(expected_image_name)
+      expect(subject.send(:image_name_conversion)).to eq(expected_image_name)
     end
 
     it "selects the right image ocid for Oracle-Linux-9.3" do


### PR DESCRIPTION
# 1.25.0
- feat: allow `image_name` to function the same for ARM as it does for Linux

Will allow Arm and Linux platforms just use the same suite as `Oracle Linux 8.\d+` will just work for both now without needing to specify `Oracle Linux 8.\d+-aarch64` now for just Arm shapes