### PR TITLE
feat: add instance_options to compute instance type

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ These settings are optional:
      - `volume_id`, If you wish to clone your volume from an existing volume set this to the source volume's ID. They must be in the same Availability Domain.
    - `nsg_ids`, The option to connect up to 5 Network Security Groups to compute instance.
    - `custom_metadata`, Add metadata to the compute instance request
+   - `instance_options`, A hash of optional mutable instance options
+      - `are_legacy_imds_endpoints_disabled`, Whether the IMDSv1 endpoint is disabled on the instance.
+        Customers who have [migrated to IMDSv2](https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/gettingmetadata.htm#upgrading-v2)
+        should set this to `true`
    - `all_plugins_disabled`, Whether Oracle Cloud Agent can run all the available plugins (default: `false`)
    - `management_disabled`, Whether Oracle Cloud Agent can run all the available management plugins (default: `false`)
    - `monitoring_disabled`, Whether Oracle Cloud Agent can gather performance metrics and monitor the instance using the monitoring plugins (default: `false`)

--- a/README.md
+++ b/README.md
@@ -121,10 +121,11 @@ These settings are optional:
      - `volume_id`, If you wish to clone your volume from an existing volume set this to the source volume's ID. They must be in the same Availability Domain.
    - `nsg_ids`, The option to connect up to 5 Network Security Groups to compute instance.
    - `custom_metadata`, Add metadata to the compute instance request
-   - `instance_options`, A hash of optional mutable instance options
-      - `are_legacy_imds_endpoints_disabled`, Whether the IMDSv1 endpoint is disabled on the instance.
-        Customers who have [migrated to IMDSv2](https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/gettingmetadata.htm#upgrading-v2)
-        should set this to `true`
+   - `instance_options`, A hash of optional mutable instance options.
+     Initially, the only option [supported in the Ruby SDK](https://docs.oracle.com/en-us/iaas/tools/ruby/latest/OCI/Core/Models/InstanceOptions.html)
+     is `are_legacy_imds_endpoints_disabled`.
+     Customers who have [migrated to IMDSv2](https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/gettingmetadata.htm#upgrading-v2) 
+     should set this to `true`
    - `all_plugins_disabled`, Whether Oracle Cloud Agent can run all the available plugins (default: `false`)
    - `management_disabled`, Whether Oracle Cloud Agent can run all the available management plugins (default: `false`)
    - `monitoring_disabled`, Whether Oracle Cloud Agent can gather performance metrics and monitor the instance using the monitoring plugins (default: `false`)

--- a/lib/kitchen/driver/oci.rb
+++ b/lib/kitchen/driver/oci.rb
@@ -82,6 +82,7 @@ module Kitchen
       default_config :post_create_reboot, false
 
       # compute only configs
+      default_config :instance_options, {}
       default_config :capacity_reservation_id
       default_config :setup_winrm, false
       default_config :winrm_user, "opc"

--- a/lib/kitchen/driver/oci/instance/compute.rb
+++ b/lib/kitchen/driver/oci/instance/compute.rb
@@ -85,15 +85,7 @@ module Kitchen
           def instance_options
             return if config[:instance_options].empty?
 
-            instance_options = {}
-            config[:instance_options].each do |k, v|
-              case k
-              when :are_legacy_imds_endpoints_disabled
-                instance_options[:are_legacy_imds_endpoints_disabled] = v
-              end
-            end
-
-            launch_details.instance_options = OCI::Core::Models::InstanceOptions.new(instance_options)
+            launch_details.instance_options = OCI::Core::Models::InstanceOptions.new(config[:instance_options])
           end
 
           # Adds the source_details property to the launch_details for an instance that is being created from a boot volume.

--- a/lib/kitchen/driver/oci/instance/compute.rb
+++ b/lib/kitchen/driver/oci/instance/compute.rb
@@ -81,6 +81,21 @@ module Kitchen
             )
           end
 
+          # Adds the instance options property to the launch details.
+          def instance_options
+            return if config[:instance_options].empty?
+
+            instance_options = {}
+            config[:instance_options].each do |k, v|
+              case k
+              when :are_legacy_imds_endpoints_disabled
+                instance_options[:are_legacy_imds_endpoints_disabled] = v
+              end
+            end
+
+            launch_details.instance_options = OCI::Core::Models::InstanceOptions.new(instance_options)
+          end
+
           # Adds the source_details property to the launch_details for an instance that is being created from a boot volume.
           def instance_source_via_boot_volume
             return unless config[:boot_volume_id]

--- a/lib/kitchen/driver/oci_version.rb
+++ b/lib/kitchen/driver/oci_version.rb
@@ -22,6 +22,6 @@ module Kitchen
     # Version string for Oracle OCI Kitchen driver
     #
     # @author Stephen Pearson (<stephen.pearson@oracle.com>)
-    OCI_VERSION = "1.27.0"
+    OCI_VERSION = "1.28.0"
   end
 end


### PR DESCRIPTION
instance_options is a hash of optional, mutable instance properties. Right now, OCI only supports one option for the hash - are_legacy_imds_endpoints_disabled, which is used to disable the legacy instance metadata endpoint. 

OCI defaults it to false, as IMDSv2 requires a relatively recent version of cloud-init.