### PR TITLE
feat: set are_legacy_imds_endpoints_disabled to true during instance creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # kitchen-oci CHANGELOG
 
+# 3.0.0
+- feat: default value for `are_legacy_imds_endpoints_disabled` of `true` set at instance provisioning time
+  > BREAKING CHANGE: This change creates a situation where older images can get stuck in a `wait_until_ready` loop
+  > Please see README for documentation about the new option to apply instance options in the post-create phase
+
 # 2.1.0
 - feat: add support for `ED25519` ssh keys.
 

--- a/README.md
+++ b/README.md
@@ -422,6 +422,22 @@ driver:
     are_legacy_imds_endpoints_disabled: false
 ```
 
+In some rare circumstances with older Windows images, disabling IMDSv1 at launch time has observed to interfere with the initial WinRM transport verification such that `kitchen-oci` never receives a success or failure handhsake
+and the `kitchen create` process never completes successfully. In the event you find yourself in this situation, the driver now offers the following option to restore `kitchen-oci 2.x` functionality where the instance options are
+applied in a post-create phase:
+
+```yml
+---
+driver:
+  name: oci
+  instance_options:
+    post_create: true
+    are_legacy_imds_endpoints_disabled: true
+```
+
+Note that this option should only be used for scenarios that specifically require it. If you are provisioning into a tenancy where IMDSv1 being enabled at launch time is explicitly forbidden, this option will not work. In that case,
+using the default `kitchen-oci 3.x` behavior is the only option.
+
 ## Windows Support
 
 When launching Oracle provided Windows images, it may be helpful to allow kitchen-oci to inject powershell to configure WinRM and to set a randomized password that does not need to be changed on first login.  If the `setup_winrm` parameter is set to true then the following steps will happen:

--- a/README.md
+++ b/README.md
@@ -422,9 +422,9 @@ driver:
     are_legacy_imds_endpoints_disabled: false
 ```
 
-In some rare circumstances with older Windows images, disabling IMDSv1 at launch time has observed to interfere with the initial WinRM transport verification such that `kitchen-oci` never receives a success or failure handhsake
-and the `kitchen create` process never completes successfully. In the event you find yourself in this situation, the driver now offers the following option to restore `kitchen-oci 2.x` functionality where the instance options are
-applied in a post-create phase:
+In some rare circumstances with older Windows images, disabling IMDSv1 at launch time has been observed to interfere with the initial WinRM transport verification such that `kitchen-oci` never receives a success or failure handshake. As a result, the `kitchen create` process never completes successfully.
+
+If you encounter this behavior, the driver provides an option to apply instance options in a post-create phase, matching the behavior of `kitchen-oci 2.x`. The following example demonstrates how to disable IMDSv1 after the instance has been created:
 
 ```yml
 ---

--- a/lib/kitchen/driver/oci/instance/compute.rb
+++ b/lib/kitchen/driver/oci/instance/compute.rb
@@ -100,10 +100,10 @@ module Kitchen
           # This ensures IMDSv2 is enabled from instance creation, which is required by OCI security policies
           # that deny instance creation when areLegacyEndpointsDisabled='false'.
           def launch_instance_options
-            opts = config[:instance_options] || {}
-            opts[:are_legacy_imds_endpoints_disabled] = true unless opts.key?(:are_legacy_imds_endpoints_disabled)
-            return if opts.empty?
+            opts = config[:instance_options].dup
+            return if opts.delete(:post_create)
 
+            opts[:are_legacy_imds_endpoints_disabled] = true unless opts.key?(:are_legacy_imds_endpoints_disabled)
             launch_details.instance_options = OCI::Core::Models::InstanceOptions.new(opts)
           end
         end

--- a/lib/kitchen/driver/oci/mixin/actions.rb
+++ b/lib/kitchen/driver/oci/mixin/actions.rb
@@ -97,10 +97,12 @@ module Kitchen
           # Acts as a guard for setting instance options.
           def instance_options?
             return false unless config[:instance_type] == "compute"
+            return false unless config[:instance_options].delete(:post_create)
 
-            config[:instance_options].merge!(are_legacy_imds_endpoints_disabled: true) unless config[:instance_options].key?(:are_legacy_imds_endpoints_disabled)
+            opts = config[:instance_options]
+            opts.merge!(are_legacy_imds_endpoints_disabled: true) unless opts.key?(:are_legacy_imds_endpoints_disabled)
             # Basically tell me if there's more stuff in there than `are_legacy_imds_endpoints_disabled: false`. If so, then proceed to setting it.
-            config[:instance_options].reject { |o, v| o == :are_legacy_imds_endpoints_disabled && !v }.any?
+            opts.reject { |o, v| o == :are_legacy_imds_endpoints_disabled && !v }.any?
           end
 
           # Checks if legacy metadata is disabled.

--- a/lib/kitchen/driver/oci_version.rb
+++ b/lib/kitchen/driver/oci_version.rb
@@ -22,6 +22,6 @@ module Kitchen
     # Version string for Oracle OCI Kitchen driver
     #
     # @author Stephen Pearson (<stephen.pearson@oracle.com>)
-    OCI_VERSION = "2.1.0"
+    OCI_VERSION = "3.0.0"
   end
 end

--- a/spec/kitchen/driver/compute_spec.rb
+++ b/spec/kitchen/driver/compute_spec.rb
@@ -61,6 +61,28 @@ describe Kitchen::Driver::Oci::Models::Compute do
       end
     end
 
+    context "standard compute (Windows) with post-create instance options" do
+      let(:driver_config) do
+        base_driver_config.merge!({
+                                    instance_options: {
+                                      post_create: true,
+                                      are_legacy_imds_endpoints_disabled: true,
+                                    },
+                                  })
+      end
+
+      it "creates a compute instance without launch-time instance options" do
+        expect(compute_client).to receive(:launch_instance).with(launch_instance_request_backward_compat)
+        driver.create(state)
+        expect(state).to match(
+                           {
+                             hostname: private_ip,
+                             server_id: instance_ocid,
+                           }
+                         )
+      end
+    end
+
     context "standard compute (Windows) with custom metadata" do
       # kitchen.yml driver config section
       let(:driver_config) do

--- a/spec/spec_helper/compute_helper.rb
+++ b/spec/spec_helper/compute_helper.rb
@@ -36,27 +36,18 @@ RSpec.shared_context "compute", :compute do
     }
   end
   let(:capacity_reservation) { "ocid1.capacityreservation.oc1.fake.aaaaaaaaaabcdefghijklmnopqrstuvwxyz12345" }
-  let(:launch_instance_request) do
+  let(:launch_instance_request_base) do
     OCI::Core::Models::LaunchInstanceDetails.new.tap do |l|
       l.availability_domain = availability_domain
       l.compartment_id = compartment_ocid
       l.display_name = hostname
-      l.source_details = OCI::Core::Models::InstanceSourceViaImageDetails.new(
-        sourceType: "image",
-        imageId: image_ocid,
-        bootVolumeSizeInGBs: nil
-      )
       l.shape = shape
-      l.capacity_reservation_id = capacity_reservation
       l.create_vnic_details = OCI::Core::Models::CreateVnicDetails.new(
         assign_public_ip: false,
         display_name: hostname,
         hostname_label: hostname,
         nsg_ids: driver_config[:nsg_ids],
         subnet_id: subnet_ocid
-      )
-      l.instance_options = OCI::Core::Models::InstanceOptions.new(
-        are_legacy_imds_endpoints_disabled: true
       )
       l.freeform_tags = { kitchen: true }
       l.defined_tags = {}
@@ -67,35 +58,41 @@ RSpec.shared_context "compute", :compute do
         are_all_plugins_disabled: false
       )
     end
+
   end
 
-  let(:launch_instance_from_bv_request) do
-    OCI::Core::Models::LaunchInstanceDetails.new.tap do |l|
-      l.availability_domain = availability_domain
-      l.compartment_id = compartment_ocid
-      l.display_name = hostname
-      l.source_details = OCI::Core::Models::InstanceSourceViaBootVolumeDetails.new(
-        sourceType: "bootVolume",
-        boot_volume_id: clone_boot_volume_ocid
-      )
-      l.shape = shape
-      l.create_vnic_details = OCI::Core::Models::CreateVnicDetails.new(
-        assign_public_ip: false,
-        display_name: hostname,
-        hostname_label: hostname,
-        nsg_ids: driver_config[:nsg_ids],
-        subnet_id: subnet_ocid
+  let(:launch_instance_request) do
+    launch_instance_request_base.tap do |l|
+      l.source_details = OCI::Core::Models::InstanceSourceViaImageDetails.new(
+        sourceType: "image",
+        imageId: image_ocid,
+        bootVolumeSizeInGBs: nil
       )
       l.instance_options = OCI::Core::Models::InstanceOptions.new(
         are_legacy_imds_endpoints_disabled: true
       )
-      l.freeform_tags = { kitchen: true }
-      l.defined_tags = {}
-      l.metadata = instance_metadata
-      l.agent_config = OCI::Core::Models::LaunchInstanceAgentConfigDetails.new(
-        is_monitoring_disabled: false,
-        is_management_disabled: false,
-        are_all_plugins_disabled: false
+      l.capacity_reservation_id = capacity_reservation
+    end
+  end
+
+  let(:launch_instance_from_bv_request) do
+    launch_instance_request_base.tap do |l|
+      l.source_details = OCI::Core::Models::InstanceSourceViaBootVolumeDetails.new(
+        sourceType: "bootVolume",
+        boot_volume_id: clone_boot_volume_ocid
+      )
+      l.instance_options = OCI::Core::Models::InstanceOptions.new(
+        are_legacy_imds_endpoints_disabled: true
+      )
+    end
+  end
+
+  let(:launch_instance_request_backward_compat) do
+    launch_instance_request_base.tap do |l|
+      l.source_details = OCI::Core::Models::InstanceSourceViaImageDetails.new(
+        sourceType: "image",
+        imageId: image_ocid,
+        bootVolumeSizeInGBs: nil
       )
     end
   end


### PR DESCRIPTION
default value for `are_legacy_imds_endpoints_disabled` of `true` set at instance provisioning time
  > BREAKING CHANGE: This change creates a situation where older images can get stuck in a `wait_until_ready` loop
  > Please see README for documentation about the new option to apply instance options in the post-create phase